### PR TITLE
Added available space check before plot preallocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9538,6 +9538,7 @@ dependencies = [
  "dirs",
  "event-listener-primitives",
  "fdlimit",
+ "fs2",
  "futures 0.3.25",
  "hex",
  "jemallocator",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -23,6 +23,7 @@ derive_more = "0.99.17"
 dirs = "4.0.0"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.2"
+fs2 = "0.4.3"
 futures = "0.3.25"
 hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.16.2", features = ["client", "macros", "server"] }


### PR DESCRIPTION
Moved to draft, since I realized that I missed metadata`preallocation`, that can be huge too.
I'm going to fix it soon, sorry that bothered you with notifications :)

---
This PR fixes the problem, when somebody trying to allocate plot with size, that is greater then available space for that directory.
added:

- fs2 dependency to `subspace-farmer` module
- `available_space` check for the plot path
- custom error for this case `InsufficientAvailableSpace` to `SingleDiskPlotError`

Also, I used `>=` to compare between `plot_size` and `available_space` to make it impossible to create a plot file, that fits disk space up to the max capacity. We can discuss this, I can be wrong :)

Output now:
```
./subspace-farmer --base-path . --farm path=$HOME/Library/Application\ Support,size=10000G farm --reward-address st...
2023-02-02T18:56:41.773074Z  INFO subspace_farmer::utils: Increase file limit from soft to hard (limit is 61440)
2023-02-02T18:56:41.775679Z  INFO subspace_farmer::commands::farm: Connecting to node RPC at ws://127.0.0.1:9944
2023-02-02T18:56:41.825392Z  INFO subspace_farmer::commands::farm::dsn: Record cache DB configured. piece_cache_db_path="./piece_cache_db" piece_cache_size=65536 provider_cache_db_path="./provider_cache_db" provider_cache_size=655360
2023-02-02T18:56:41.842349Z  INFO subspace_networking::behavior::provider_storage::providers: New record cache initialized. path="./provider_cache_db"
2023-02-02T18:56:41.850017Z  INFO subspace_farmer::utils::farmer_piece_cache: New local piece cache initialized.
2023-02-02T18:56:41.852966Z  INFO subspace_networking::create: DSN instance configured. allow_non_global_addresses_in_dht=true peer_id=12D3KooWPvB5kYvQT7Tp4dQfTp88VxQk6XymUf87Wphp74nrQ8AQ
2023-02-02T18:56:41.859332Z  INFO subspace_farmer::commands::farm: Connecting to node RPC at ws://127.0.0.1:9944
Error: Available disk space is not enough, path: /Users/hazyone/Library/Application Support/plot.bin The maximum acceptable value for this directory is: 25.1 GB, you requested: 10.0 TB. 
```

Closes issue #1048 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
