### PR TITLE
Fix `subspace-node` purge-chain command

### DIFF
--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -60,6 +60,7 @@ impl NativeExecutionDispatch for ExecutorDispatch {
 
 /// This `purge-chain` command used to remove both consensus chain and system domain.
 #[derive(Debug, Clone, Parser)]
+#[group(skip)]
 pub struct PurgeChainCmd {
     /// The base struct of the purge-chain command.
     #[clap(flatten)]


### PR DESCRIPTION
This PR fixes problem #1215 for the`subspace-node`.

As I realized, `clap-rs` made implicit ArgGroup creation, and `PurgeChainCmd` contains the same named struct in it:
```rust
pub struct PurgeChainCmd {
    /// The base struct of the purge-chain command.
    #[clap(flatten)]
    pub base: sc_cli::PurgeChainCmd,
}
``` 

So, as mentioned in the error description, we have to use `#[group(skip)]` to avoid this behavior.

After fixing the command works as desired:
```bash
 > ./subspace-node purge-chain -d nodee/ --chain gemini-3c

nodee/system/chains/subspace_gemini_3c_system_domain/paritydb/full
nodee/chains/subspace_gemini_3c/paritydb/full
Are you sure to remove? [y/N]: y
"nodee/system/chains/subspace_gemini_3c_system_domain/paritydb/full" did not exist.
"nodee/chains/subspace_gemini_3c/paritydb/full" removed.

...
> ls nodee/chains/subspace_gemini_3c/paritydb/full
ls: nodee/chains/subspace_gemini_3c/paritydb/full: No such file or directory

```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
